### PR TITLE
fix: harden GitHub Actions against supply chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,9 +20,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 22
           cache: npm
@@ -36,7 +36,7 @@ jobs:
 
       - run: npx astro build
 
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: dist/
 
@@ -48,4 +48,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions references to immutable commit SHAs (prevents tag/branch force-push attacks)
- Add Dependabot configuration for automatic GitHub Actions version updates

## Context

On 2026-03-19, `aquasecurity/trivy-action` was compromised via a tag force-push attack that exfiltrated secrets from CI runners. SHA-pinning prevents this class of attack entirely.

The netresearch org now enforces `sha_pinning_required=true` — workflows using tag/branch references will fail.

Ref: https://github.com/netresearch/ofelia/issues/535

## Test plan

- [ ] Verify CI passes with SHA-pinned actions
- [ ] Verify Dependabot creates PRs for action updates