### PR TITLE
ci: add auto-merge workflow for dependency PRs

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -1,0 +1,35 @@
+name: Auto-merge dependency PRs
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' ||
+      github.event.pull_request.user.login == 'renovate[bot]'
+    steps:
+      - name: Approve PR
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr review --approve "$PR_URL"
+
+      - name: Enable auto-merge
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          STRATEGY=$(gh api "repos/$REPO" --jq '
+            if .allow_squash_merge then "--squash"
+            elif .allow_merge_commit then "--merge"
+            elif .allow_rebase_merge then "--rebase"
+            else "--merge" end')
+          gh pr merge --auto "$STRATEGY" "$PR_URL"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/auto-merge-deps.yml` to automatically approve and merge dependency update PRs from `dependabot[bot]` and `renovate[bot]`
- Detects the repo's preferred merge strategy (squash/merge/rebase) at runtime
- Uses `pull_request_target` to ensure the workflow has write permissions even for fork-based dependency PRs

## Test plan

- [ ] Verify workflow triggers on the next Dependabot or Renovate PR
- [ ] Confirm the PR is approved and auto-merge is enabled automatically