### PR TITLE
Add Live Sites & Pages index of all org GitHub Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 .astro/
 .DS_Store
 src/data/github-repos.json
+src/data/github-pages.json

--- a/scripts/fetch-repos.mjs
+++ b/scripts/fetch-repos.mjs
@@ -6,6 +6,7 @@ import yaml from 'js-yaml';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const OUTPUT = join(__dirname, '..', 'src', 'data', 'github-repos.json');
+const PAGES_OUTPUT = join(__dirname, '..', 'src', 'data', 'github-pages.json');
 
 const TWO_YEARS_AGO = new Date();
 TWO_YEARS_AGO.setFullYear(TWO_YEARS_AGO.getFullYear() - 2);
@@ -205,4 +206,59 @@ function classifyBadge(alt, url) {
   return { type: badgeType, alt: alt || badgeType, url };
 }
 
+/**
+ * Fetch every org repo that publishes a GitHub Pages site, independent of the
+ * repo-card filters (archived / no-description / stale), so long-lived live
+ * sites still appear. Resolves the canonical URL (custom domain or
+ * netresearch.github.io path) via the per-repo Pages API.
+ */
+function fetchLivePages() {
+  const raw = execSync(
+    'gh api orgs/netresearch/repos --paginate ' +
+      "--jq '.[] | select(.has_pages == true and .archived == false) " +
+      "| {name, description, html_url, homepage, pushed_at}'",
+    { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 },
+  );
+
+  const pages = raw
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line))
+    // Skip the org root repo — that's this very site.
+    .filter((r) => r.name !== 'netresearch.github.io')
+    .map((r) => {
+      const page = {
+        name: r.name,
+        description: r.description || '',
+        repoUrl: r.html_url,
+        pushed_at: r.pushed_at,
+        url: `https://netresearch.github.io/${r.name}/`,
+      };
+
+      // Resolve the authoritative Pages URL (honours custom CNAMEs and the
+      // org root page at netresearch.github.io/).
+      try {
+        const info = JSON.parse(
+          execSync(`gh api repos/netresearch/${r.name}/pages`, {
+            encoding: 'utf-8',
+            stdio: 'pipe',
+            timeout: 10000,
+          }).trim(),
+        );
+        if (info.html_url) page.url = info.html_url;
+        if (info.cname) page.cname = info.cname;
+      } catch {
+        // Pages API unavailable (e.g. building) — keep the derived URL.
+      }
+      return page;
+    })
+    .sort((a, b) => new Date(b.pushed_at) - new Date(a.pushed_at));
+
+  mkdirSync(dirname(PAGES_OUTPUT), { recursive: true });
+  writeFileSync(PAGES_OUTPUT, JSON.stringify(pages, null, 2));
+  console.log(`Wrote ${pages.length} live pages to ${PAGES_OUTPUT}`);
+}
+
 fetchRepos();
+fetchLivePages();

--- a/src/components/LivePagesSection.astro
+++ b/src/components/LivePagesSection.astro
@@ -1,0 +1,31 @@
+---
+import PageCard from './PageCard.astro';
+import type { LivePage } from '../data/load-pages';
+
+interface Props {
+  pages: LivePage[];
+  alternateBackground?: boolean;
+}
+
+const { pages, alternateBackground = false } = Astro.props;
+---
+
+{pages.length > 0 && (
+  <section id="live-pages" class:list={["py-20 relative", alternateBackground && "bg-surface-alt"]}>
+    <div class="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-border to-transparent"></div>
+    <div class="max-w-7xl mx-auto px-6">
+      <div class="mb-12" data-animate="fade-up">
+        <h2 class="text-sm font-heading uppercase tracking-[0.2em] text-nr-teal mb-3">Live Sites &amp; Pages</h2>
+        <div class="w-12 h-0.5 bg-nr-teal/30"></div>
+        <p class="mt-4 text-sm text-text-secondary max-w-2xl">
+          Every site we publish via GitHub Pages. Updated automatically.
+        </p>
+      </div>
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {pages.map((page) => (
+          <PageCard page={page} />
+        ))}
+      </div>
+    </div>
+  </section>
+)}

--- a/src/components/PageCard.astro
+++ b/src/components/PageCard.astro
@@ -1,0 +1,45 @@
+---
+import type { LivePage } from '../data/load-pages';
+
+interface Props {
+  page: LivePage;
+}
+
+const { page } = Astro.props;
+const host = (() => {
+  try {
+    return new URL(page.url).host;
+  } catch {
+    return page.url;
+  }
+})();
+---
+
+<a
+  href={page.url}
+  target="_blank"
+  rel="noopener"
+  class="group block rounded-xl border border-border bg-surface-card p-5 transition-all duration-300 hover:border-border-hover hover:bg-surface-hover hover:-translate-y-0.5 card-shadow"
+  data-animate="fade-up"
+  aria-label={`${page.name} — ${page.description}`}
+>
+  <div class="flex items-start justify-between mb-2 gap-2">
+    <h3 class="font-heading font-bold text-text-primary group-hover:text-nr-teal transition-colors text-sm truncate">
+      {page.name}
+    </h3>
+    <span class="flex items-center gap-1 text-xs text-nr-teal shrink-0" aria-hidden="true">
+      <svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M13.828 10.172a4 4 0 010 5.656l-3 3a4 4 0 01-5.656-5.656l1.5-1.5M10.172 13.828a4 4 0 010-5.656l3-3a4 4 0 015.656 5.656l-1.5 1.5"/></svg>
+      Live
+    </span>
+  </div>
+  {page.description && (
+    <p class="text-xs text-text-secondary line-clamp-2 mb-3 leading-relaxed">{page.description}</p>
+  )}
+  <div class="flex items-center gap-2 text-xs text-text-secondary truncate">
+    <span class="w-1.5 h-1.5 rounded-full bg-nr-teal shrink-0" aria-hidden="true"></span>
+    <span class="truncate">{host}</span>
+    {page.cname && (
+      <span class="px-1.5 py-0.5 rounded bg-nr-teal/10 text-nr-teal text-[10px] uppercase tracking-wide shrink-0">custom domain</span>
+    )}
+  </div>
+</a>

--- a/src/components/PageCard.astro
+++ b/src/components/PageCard.astro
@@ -21,7 +21,7 @@ const host = (() => {
   rel="noopener"
   class="group block rounded-xl border border-border bg-surface-card p-5 transition-all duration-300 hover:border-border-hover hover:bg-surface-hover hover:-translate-y-0.5 card-shadow"
   data-animate="fade-up"
-  aria-label={`${page.name} — ${page.description}`}
+  aria-label={page.description ? `${page.name} — ${page.description}` : page.name}
 >
   <div class="flex items-start justify-between mb-2 gap-2">
     <h3 class="font-heading font-bold text-text-primary group-hover:text-nr-teal transition-colors text-sm truncate">

--- a/src/data/load-pages.ts
+++ b/src/data/load-pages.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface LivePage {
+  name: string;
+  description: string;
+  /** Canonical published URL (custom domain or netresearch.github.io path). */
+  url: string;
+  /** Source repository URL. */
+  repoUrl: string;
+  pushed_at: string;
+  /** Custom domain, when configured. */
+  cname?: string;
+}
+
+/**
+ * Load the GitHub Pages sites published across the organisation.
+ * Data is produced at build time by scripts/fetch-repos.mjs.
+ */
+export function loadPages(): LivePage[] {
+  try {
+    const raw = readFileSync(
+      join(process.cwd(), 'src/data/github-pages.json'),
+      'utf-8',
+    );
+    return JSON.parse(raw) as LivePage[];
+  } catch {
+    console.warn('github-pages.json not found — run: npm run fetch-repos');
+    return [];
+  }
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,10 +5,13 @@ import Hero from '../components/Hero.astro';
 import StatsBar from '../components/StatsBar.astro';
 import FeaturedSection from '../components/FeaturedSection.astro';
 import CategorySection from '../components/CategorySection.astro';
+import LivePagesSection from '../components/LivePagesSection.astro';
 import Footer from '../components/Footer.astro';
 import { loadProjects } from '../data/load-projects';
+import { loadPages } from '../data/load-pages';
 
 const data = loadProjects();
+const livePages = loadPages();
 ---
 
 <Layout title="Netresearch Open Source">
@@ -21,8 +24,9 @@ const data = loadProjects();
       languages={data.stats.languages}
     />
     <FeaturedSection projects={data.featured} />
+    <LivePagesSection pages={livePages} />
     {data.categories.map((cat, i) => (
-      <CategorySection category={cat} repos={data.byCategory[cat.id] || []} alternateBackground={i % 2 === 1} />
+      <CategorySection category={cat} repos={data.byCategory[cat.id] || []} alternateBackground={i % 2 === 0} />
     ))}
   </main>
   <Footer />


### PR DESCRIPTION
## What

Adds a **"Live Sites & Pages"** section to the home page listing every GitHub Pages site the org publishes (11 today), so we have a single index of all our live pages.

## How

- `scripts/fetch-repos.mjs` — new `fetchLivePages()` enumerates org repos with `has_pages` (non-archived), **independent of the existing repo-card filters** so long-lived but stale/undescribed sites still show up. Resolves the canonical URL via the per-repo Pages API (honours custom CNAMEs and the org root page) and writes `src/data/github-pages.json` (gitignored build output, like `github-repos.json`). The org root repo is excluded to avoid self-reference.
- `src/data/load-pages.ts` — typed loader.
- `src/components/LivePagesSection.astro` + `PageCard.astro` — new section, matching the existing card styling, with a "custom domain" tag where applicable.

## Pipeline

None added — the existing daily `deploy.yml` (cron + push + dispatch) already rebuilds and republishes, so the index self-updates.

## Test plan

- [x] `node scripts/fetch-repos.mjs` → writes `github-pages.json` (11 sites)
- [x] `npx astro build` succeeds
